### PR TITLE
fix dotnet cli run config

### DIFF
--- a/StsServer/Properties/launchSettings.json
+++ b/StsServer/Properties/launchSettings.json
@@ -18,14 +18,11 @@
     "StsServerIdentity": {
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "http://localhost:5000",
+      "launchUrl": "http://localhost:44352/",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
-    "newProfile1": {
-      "commandName": "IISExpress",
-      "launchBrowser": true
+      },
+      "applicationUrl": "http://localhost:44352/"
     }
   }
 }


### PR DESCRIPTION
StsServer try to run on 5000 port when use [dotnet run] command.
StsServer port is 44352 and this set only in IIS config.